### PR TITLE
Consolidate local orchestration into a single Makefile workflow + prod migrate/import target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Thumbs.db
 .env*
 !.env.example
 !.env.prod.example
+artifacts/

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,45 @@
-.PHONY: help init-env env-dev env-prod env-check up down reset logs bootstrap seed-db ps
+.PHONY: \
+	help init init-env env-dev env-prod env-check \
+	up down logs ps \
+	migrate-db preprocess vlm-predictions enrich-addresses all-preprocessing \
+	export-db import-db \
+	bootstrap reset
 
 COMPOSE := docker compose -f docker-compose.yml
 DATASET_DEFAULT := ../florence-hurricane-complete/data-example
 PARSED_JSON := /app/data-example/parsed_data.json
+SNAPSHOT_HOST := ./artifacts/db_snapshot.json
+SNAPSHOT_CONTAINER := /tmp/db_snapshot.json
 
 help:
 	@echo "Targets:"
-	@echo "  make init-env   - create .env and .env.prod from examples (if missing)"
-	@echo "  make env-dev    - copy .env.example -> .env"
-	@echo "  make env-prod   - copy .env.prod.example -> .env.prod and .env"
-	@echo "  make up         - start postgis, backend, frontend"
-	@echo "  make bootstrap  - start stack and load parsed_data.json into DB"
-	@echo "  make seed-db    - load parsed_data.json into DB (backend must be up)"
-	@echo "  make logs       - tail logs for all services"
-	@echo "  make ps         - show service status"
-	@echo "  make down       - stop stack"
-	@echo "  make reset      - destroy DB volume and restart clean"
+	@echo "  make help              - display this menu"
+	@echo "  make init              - basic initialization checks"
+	@echo "  make init-env          - create .env and .env.prod from examples (if missing)"
+	@echo "  make preprocess        - load parsed_data.json into DB (base preprocessing)"
+	@echo "  make vlm-predictions   - run VLM predictions into chat.vlm_assessments"
+	@echo "  make enrich-addresses  - enrich addresses in locations table"
+	@echo "  make all-preprocessing - run preprocess + vlm-predictions + enrich-addresses"
+	@echo "  make export-db         - export DB snapshot JSON to $(SNAPSHOT_HOST)"
+	@echo "  make import-db         - import snapshot JSON from $(SNAPSHOT_HOST) safely"
+	@echo "  make up                - start postgis + backend + frontend"
+	@echo "  make down              - stop stack"
+	@echo "  make logs              - tail logs"
+	@echo "  make bootstrap         - first-time machine setup flow"
+	@echo "  make reset             - reset running setup (fresh DB + full preprocessing)"
 
 init-env:
 	@if [ ! -f .env ]; then cp .env.example .env; echo "Created .env from .env.example"; fi
 	@if [ ! -f .env.prod ]; then cp .env.prod.example .env.prod; echo "Created .env.prod from .env.prod.example"; fi
+
+env-dev:
+	cp .env.example .env
+	@echo "Active env set to dev via .env.example"
+
+env-prod:
+	cp .env.prod.example .env.prod
+	cp .env.prod .env
+	@echo "Active env set to prod via .env.prod"
 
 env-check:
 	@$(MAKE) init-env
@@ -28,22 +48,25 @@ env-check:
 		echo "Expected parsed_data.json at: $${HOST_DATA_EXAMPLE_DIR:-$(DATASET_DEFAULT)}/parsed_data.json"; \
 		exit 1; \
 	fi
+	@if [ ! -f "$${HOST_DATA_EXAMPLE_DIR:-$(DATASET_DEFAULT)}/parsed_data.json" ]; then \
+		echo "Missing parsed_data.json at: $${HOST_DATA_EXAMPLE_DIR:-$(DATASET_DEFAULT)}/parsed_data.json"; \
+		exit 1; \
+	fi
 	@if [ ! -d "$${HOST_DATA_EXAMPLE_DIR:-$(DATASET_DEFAULT)}/images/hurricane-florence" ]; then \
 		echo "Images directory missing: $${HOST_DATA_EXAMPLE_DIR:-$(DATASET_DEFAULT)}/images/hurricane-florence"; \
 		exit 1; \
 	fi
+	@mkdir -p artifacts
 
-up: env-check
+init: env-check
+	@echo "Initialization checks complete."
+
+up: init
 	$(COMPOSE) up -d --build postgis backend frontend
 	$(COMPOSE) ps
 
-seed-db:
-	$(COMPOSE) exec -T backend test -f $(PARSED_JSON)
-	$(COMPOSE) exec -T backend python util/preprocess-data.py --start-at load --stop-after load --input $(PARSED_JSON)
-	@echo "Dataset loaded into PostGIS."
-
-bootstrap: up
-	$(MAKE) seed-db
+down:
+	$(COMPOSE) down
 
 logs:
 	$(COMPOSE) logs -f --tail=200
@@ -51,10 +74,54 @@ logs:
 ps:
 	$(COMPOSE) ps
 
-down:
-	$(COMPOSE) down
+migrate-db:
+	$(COMPOSE) exec -T backend python -m util.migrate
+	@echo "Migrations applied."
+
+preprocess: migrate-db
+	$(COMPOSE) exec -T backend test -f $(PARSED_JSON)
+	$(COMPOSE) exec -T backend sh -lc "PYTHONPATH=/app python util/preprocess-data.py --start-at load --stop-after load --input $(PARSED_JSON)"
+	@echo "Preprocess load complete."
+
+vlm-predictions:
+	$(COMPOSE) exec -T backend sh -lc "PYTHONPATH=/app python util/preprocess-data.py --start-at vlm --stop-after vlm"
+	@echo "VLM predictions complete."
+
+enrich-addresses:
+	@echo "Enriching addresses in batches..."
+	@while true; do \
+		remaining=$$($(COMPOSE) exec -T postgis psql -U utd -d utd_data -t -A -c "SELECT COUNT(*) FROM locations WHERE address_fetched_at IS NULL;"); \
+		remaining=$$(echo $$remaining | tr -d '[:space:]'); \
+		if [ -z "$$remaining" ] || [ "$$remaining" = "0" ]; then \
+			echo "Address enrichment complete."; \
+			break; \
+		fi; \
+		echo "Remaining rows with null address_fetched_at: $$remaining"; \
+		$(COMPOSE) exec -T backend sh -lc "PYTHONPATH=/app python -m util.enrich_addresses --limit 1000"; \
+	done
+
+all-preprocessing: preprocess vlm-predictions enrich-addresses
+	@echo "All preprocessing steps complete."
+
+export-db:
+	$(COMPOSE) exec -T backend sh -lc "PYTHONPATH=/app python /app/util/export_db_snapshot.py --output $(SNAPSHOT_CONTAINER) --pretty"
+	docker cp utd-backend:$(SNAPSHOT_CONTAINER) $(SNAPSHOT_HOST)
+	@echo "Snapshot exported to $(SNAPSHOT_HOST)"
+
+import-db:
+	@if [ ! -f "$(SNAPSHOT_HOST)" ]; then \
+		echo "Snapshot not found: $(SNAPSHOT_HOST). Run 'make export-db' first."; \
+		exit 1; \
+	fi
+	docker cp $(SNAPSHOT_HOST) utd-backend:$(SNAPSHOT_CONTAINER)
+	$(COMPOSE) exec -T backend sh -lc "PYTHONPATH=/app python /app/util/import_db_snapshot.py --input $(SNAPSHOT_CONTAINER)"
+	@echo "Seed complete from $(SNAPSHOT_HOST)"
+
+bootstrap: up all-preprocessing
+	@echo "Bootstrap complete."
 
 reset:
 	$(COMPOSE) down -v --remove-orphans
-	$(COMPOSE) up -d --build postgis backend frontend
-	$(MAKE) seed-db
+	$(MAKE) up
+	$(MAKE) all-preprocessing
+	@echo "Reset complete."

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 	help init init-env env-dev env-prod env-check \
 	up down logs ps \
 	migrate-db preprocess vlm-predictions enrich-addresses all-preprocessing \
-	export-db import-db prod-migrate-import \
+	export-db import-db verify-db-load prod-migrate-import \
 	bootstrap bootstrap-full reset
 
 COMPOSE := docker compose -f docker-compose.yml
@@ -22,6 +22,7 @@ help:
 	@echo "  make all-preprocessing - run preprocess + vlm-predictions + enrich-addresses"
 	@echo "  make export-db         - export DB snapshot JSON to $(SNAPSHOT_HOST)"
 	@echo "  make import-db         - import snapshot JSON from $(SNAPSHOT_HOST) safely"
+	@echo "  make verify-db-load    - verify required DB tables/data exist after import/load"
 	@echo "  make prod-migrate-import - run migrate-db + import-db against DATABASE_URL in .env.prod"
 	@echo "  make up                - start postgis + backend + frontend"
 	@echo "  make down              - stop stack"
@@ -72,14 +73,14 @@ logs:
 ps:
 	$(COMPOSE) ps
 
-migrate-db:
-	$(COMPOSE) exec -T backend python -m util.migrate
-	@echo "Migrations applied."
-
-preprocess: migrate-db
+preprocess:
 	$(COMPOSE) exec -T backend test -f $(PARSED_JSON)
 	$(COMPOSE) exec -T backend sh -lc "PYTHONPATH=/app python util/preprocess-data.py --start-at load --stop-after load --input $(PARSED_JSON)"
 	@echo "Preprocess load complete."
+
+migrate-db: preprocess
+	$(COMPOSE) exec -T backend python -m util.migrate
+	@echo "Migrations applied."
 
 vlm-predictions:
 	$(COMPOSE) exec -T backend sh -lc "PYTHONPATH=/app python util/preprocess-data.py --start-at vlm --stop-after vlm"
@@ -115,6 +116,20 @@ import-db:
 	$(COMPOSE) exec -T backend sh -lc "PYTHONPATH=/app python /app/util/import_db_snapshot.py --input $(SNAPSHOT_CONTAINER)"
 	@echo "Seed complete from $(SNAPSHOT_HOST)"
 
+verify-db-load:
+	$(COMPOSE) exec -T postgis psql -U utd -d utd_data -v ON_ERROR_STOP=1 -c \
+	"SELECT to_regclass('public.disasters') AS disasters, to_regclass('public.image_pairs') AS image_pairs, to_regclass('public.locations') AS locations;"
+	$(COMPOSE) exec -T postgis psql -U utd -d utd_data -v ON_ERROR_STOP=1 -c \
+	"SELECT (SELECT count(*) FROM disasters) AS disasters, (SELECT count(*) FROM image_pairs) AS image_pairs, (SELECT count(*) FROM locations) AS locations;"
+	@counts=$$($(COMPOSE) exec -T postgis psql -U utd -d utd_data -t -A -F, -c "SELECT (SELECT count(*) FROM image_pairs), (SELECT count(*) FROM locations);"); \
+	ip_count=$$(echo $$counts | cut -d, -f1 | tr -d '[:space:]'); \
+	loc_count=$$(echo $$counts | cut -d, -f2 | tr -d '[:space:]'); \
+	if [ "$$ip_count" = "0" ] || [ "$$loc_count" = "0" ]; then \
+		echo "DB verification failed: image_pairs=$$ip_count locations=$$loc_count after import/load"; \
+		exit 1; \
+	fi
+	@echo "DB verification passed."
+
 prod-migrate-import:
 	@if [ ! -f ".env.prod" ]; then \
 		echo "Missing .env.prod. Run 'make init-env' and fill .env.prod first."; \
@@ -138,7 +153,16 @@ prod-migrate-import:
 	$(COMPOSE) exec -T -e DATABASE_URL="$$prod_db_url" backend sh -lc "PYTHONPATH=/app python /app/util/import_db_snapshot.py --input $(SNAPSHOT_CONTAINER)"; \
 	echo "Prod migrate+import complete using DATABASE_URL from .env.prod"
 
-bootstrap: up migrate-db import-db
+bootstrap:
+	@if [ ! -f "$(SNAPSHOT_HOST)" ]; then \
+		echo "Bootstrap requires snapshot $(SNAPSHOT_HOST) but it was not found."; \
+		echo "Run 'make export-db' from a source environment first, then retry."; \
+		exit 1; \
+	fi
+	$(MAKE) up
+	$(MAKE) migrate-db
+	$(MAKE) import-db
+	$(MAKE) verify-db-load
 	@echo "Bootstrap (import mode) complete."
 
 bootstrap-full: up all-preprocessing

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 	up down logs ps \
 	migrate-db preprocess vlm-predictions enrich-addresses all-preprocessing \
 	export-db import-db \
-	bootstrap reset
+	bootstrap bootstrap-full reset
 
 COMPOSE := docker compose -f docker-compose.yml
 DATASET_DEFAULT := ../florence-hurricane-complete/data-example
@@ -25,16 +25,13 @@ help:
 	@echo "  make up                - start postgis + backend + frontend"
 	@echo "  make down              - stop stack"
 	@echo "  make logs              - tail logs"
-	@echo "  make bootstrap         - first-time machine setup flow"
+	@echo "  make bootstrap         - first-time bootstrap using import-db snapshot"
+	@echo "  make bootstrap-full    - full from-scratch preprocessing (includes VLM + enrich)"
 	@echo "  make reset             - reset running setup (fresh DB + full preprocessing)"
 
 init-env:
 	@if [ ! -f .env ]; then cp .env.example .env; echo "Created .env from .env.example"; fi
 	@if [ ! -f .env.prod ]; then cp .env.prod.example .env.prod; echo "Created .env.prod from .env.prod.example"; fi
-
-env-dev:
-	cp .env.example .env
-	@echo "Active env set to dev via .env.example"
 
 env-prod:
 	cp .env.prod.example .env.prod
@@ -117,8 +114,11 @@ import-db:
 	$(COMPOSE) exec -T backend sh -lc "PYTHONPATH=/app python /app/util/import_db_snapshot.py --input $(SNAPSHOT_CONTAINER)"
 	@echo "Seed complete from $(SNAPSHOT_HOST)"
 
-bootstrap: up all-preprocessing
-	@echo "Bootstrap complete."
+bootstrap: up migrate-db import-db
+	@echo "Bootstrap (import mode) complete."
+
+bootstrap-full: up all-preprocessing
+	@echo "Bootstrap (full preprocessing) complete."
 
 reset:
 	$(COMPOSE) down -v --remove-orphans

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 	help init init-env env-dev env-prod env-check \
 	up down logs ps \
 	migrate-db preprocess vlm-predictions enrich-addresses all-preprocessing \
-	export-db import-db \
+	export-db import-db prod-migrate-import \
 	bootstrap bootstrap-full reset
 
 COMPOSE := docker compose -f docker-compose.yml
@@ -22,6 +22,7 @@ help:
 	@echo "  make all-preprocessing - run preprocess + vlm-predictions + enrich-addresses"
 	@echo "  make export-db         - export DB snapshot JSON to $(SNAPSHOT_HOST)"
 	@echo "  make import-db         - import snapshot JSON from $(SNAPSHOT_HOST) safely"
+	@echo "  make prod-migrate-import - run migrate-db + import-db against DATABASE_URL in .env.prod"
 	@echo "  make up                - start postgis + backend + frontend"
 	@echo "  make down              - stop stack"
 	@echo "  make logs              - tail logs"
@@ -113,6 +114,29 @@ import-db:
 	docker cp $(SNAPSHOT_HOST) utd-backend:$(SNAPSHOT_CONTAINER)
 	$(COMPOSE) exec -T backend sh -lc "PYTHONPATH=/app python /app/util/import_db_snapshot.py --input $(SNAPSHOT_CONTAINER)"
 	@echo "Seed complete from $(SNAPSHOT_HOST)"
+
+prod-migrate-import:
+	@if [ ! -f ".env.prod" ]; then \
+		echo "Missing .env.prod. Run 'make init-env' and fill .env.prod first."; \
+		exit 1; \
+	fi
+	@if [ ! -f "$(SNAPSHOT_HOST)" ]; then \
+		echo "Snapshot not found: $(SNAPSHOT_HOST). Run 'make export-db' first."; \
+		exit 1; \
+	fi
+	@prod_db_url=$$(awk -F= '/^DATABASE_URL=/{sub(/^DATABASE_URL=/,""); print; exit}' .env.prod); \
+	if [ -z "$$prod_db_url" ]; then \
+		echo "DATABASE_URL is missing in .env.prod"; \
+		exit 1; \
+	fi; \
+	if ! $(COMPOSE) ps backend --status running >/dev/null 2>&1; then \
+		echo "Backend container is not running. Start it first with 'make up'."; \
+		exit 1; \
+	fi; \
+	docker cp $(SNAPSHOT_HOST) utd-backend:$(SNAPSHOT_CONTAINER); \
+	$(COMPOSE) exec -T -e DATABASE_URL="$$prod_db_url" backend python -m util.migrate; \
+	$(COMPOSE) exec -T -e DATABASE_URL="$$prod_db_url" backend sh -lc "PYTHONPATH=/app python /app/util/import_db_snapshot.py --input $(SNAPSHOT_CONTAINER)"; \
+	echo "Prod migrate+import complete using DATABASE_URL from .env.prod"
 
 bootstrap: up migrate-db import-db
 	@echo "Bootstrap (import mode) complete."

--- a/START.md
+++ b/START.md
@@ -34,7 +34,7 @@ Make sure to add gemini key to this file if you want to test it.
 
 If you want to test against prod db etc, set `APP_ENV=prod` in `.env` manually and make sure to add the proper api keys there.
 
-Then just run the bootstrap command to start everything.
+For first-time setup, run bootstrap once:
 
 ```sh
 make bootstrap
@@ -42,14 +42,27 @@ make bootstrap
 
 This command will:
 - start PostGIS + backend + frontend containers
+- run backend SQL migrations (`backend/migrations/*.sql`)
 - validate dataset path (`../florence-hurricane-complete/data-example` by default)
 - load `parsed_data.json` into PostGIS
+- run address enrichment (`util/enrich_addresses.py`) until `locations.full_address` is populated
+- use `data-example/address_map.json` first when present, then Census fallback for misses
 - mount full `data-example` into backend and serve images from `/assets/images/hurricane-florence/<filename>.png`
 - mount `meta/.env` and `meta/.env.prod` into backend so `APP_ENV=prod` overlays `.env.prod`
 
 If your dataset is in a different location, first set:
 ```sh
 HOST_DATA_EXAMPLE_DIR=/absolute/path/to/florence-hurricane-complete/data-example make bootstrap
+```
+
+For subsequent runs (no DB re-init/reload), use:
+```sh
+make up
+```
+
+To export the current DB-enriched addresses back into a reusable map:
+```sh
+make export-address-map
 ```
 
 You can ignore the reset of the steps in this section for most cases. They are for starting and running the individual services.

--- a/START.md
+++ b/START.md
@@ -13,152 +13,132 @@ git clone git@github.com:UTDisaster/backend.git
 git clone git@github.com:UTDisaster/meta.git
 ```
 
-Pull the full dataset from GitHub release (or download the archive manually) and extract it:
+Pull the full dataset from GitHub release (or download manually) and extract it:
 
 ```sh
 gh release download florence-complete-v1 --repo UTDisaster/meta --pattern '*.tar.gz'
 tar -xzf florence-hurricane-complete.tar.gz
 ```
 
-This will likely take a few minutes.
+This may take a few minutes.
 
-## Quick Start
+## Project Workflow (meta/Makefile)
 
-To just start everything automatically altogether, first init the env variables:
+All project orchestration is now centralized in `meta/Makefile`.
+
+From `meta/`:
+
+```sh
+cd meta
+make help
+```
+
+Current primary targets:
+
+- `make init` - basic initialization checks
+- `make init-env` - create `.env` and `.env.prod` from examples if missing
+- `make up` / `make down` - start/stop PostGIS + backend + frontend
+- `make logs` - tail logs
+- `make migrate-db` - apply backend SQL migrations
+- `make preprocess` - load `parsed_data.json` into DB
+- `make vlm-predictions` - run VLM predictions and store assessments
+- `make enrich-addresses` - fill address fields (map-first, Census fallback)
+- `make all-preprocessing` - run preprocess + VLM + enrich
+- `make export-db` - export DB snapshot JSON to `meta/artifacts/db_snapshot.json`
+- `make import-db` - import `meta/artifacts/db_snapshot.json` safely
+- `make bootstrap` - startup path using import snapshot
+- `make bootstrap-full` - full from-scratch data processing path
+- `make prod-migrate-import` - run migrate+import against `DATABASE_URL` in `.env.prod`
+- `make reset` - destroy local volumes, start fresh, then run full preprocessing
+
+## Standard Local Flows
+
+### 1) First-time setup using snapshot import (recommended)
+
 ```sh
 cd meta
 make init-env
-```
-
-Make sure to add gemini key to this file if you want to test it. 
-
-If you want to test against prod db etc, set `APP_ENV=prod` in `.env` manually and make sure to add the proper api keys there.
-
-For first-time setup, run bootstrap once:
-
-```sh
+# fill .env values (and .env.prod if needed)
+make up
 make bootstrap
 ```
 
-This command will:
-- start PostGIS + backend + frontend containers
-- run backend SQL migrations (`backend/migrations/*.sql`)
-- validate dataset path (`../florence-hurricane-complete/data-example` by default)
-- load `parsed_data.json` into PostGIS
-- run address enrichment (`util/enrich_addresses.py`) until `locations.full_address` is populated
-- use `data-example/address_map.json` first when present, then Census fallback for misses
-- mount full `data-example` into backend and serve images from `/assets/images/hurricane-florence/<filename>.png`
-- mount `meta/.env` and `meta/.env.prod` into backend so `APP_ENV=prod` overlays `.env.prod`
+`bootstrap` runs:
+- `up`
+- `migrate-db`
+- `import-db`
 
-If your dataset is in a different location, first set:
+In order for boostrap to work, you will have to have the `artifacts/db_snapshot.json` file in meta root.
+
+### 2) Full from-scratch pipeline
+
+Alternatively to re-fetch the VLM classifications and run address enrichment from API. Unless the data in the db snapshot are outdated, you shouldn't need to do this step.
+
 ```sh
-HOST_DATA_EXAMPLE_DIR=/absolute/path/to/florence-hurricane-complete/data-example make bootstrap
+cd meta
+make up
+make bootstrap-full
 ```
 
-For subsequent runs (no DB re-init/reload), use:
+`bootstrap-full` runs:
+- `up`
+- `all-preprocessing` (`preprocess`, `vlm-predictions`, `enrich-addresses`)
+
+### 3) Subsequent runs
+
 ```sh
+cd meta
 make up
 ```
 
-To export the current DB-enriched addresses back into a reusable map:
-```sh
-make export-address-map
-```
+## Data Snapshot Workflow
 
-You can ignore the reset of the steps in this section for most cases. They are for starting and running the individual services.
-
-## Manual Steps
-
-### Database and Backend
-
-cd to the backend directory.
-
-Copy `.env.example` to `.env` and add your api keys for testing. 
+### Export DB snapshot
 
 ```sh
-cp .env.example .env
-cp .env.prod.example .env.prod
+cd meta
+make export-db
 ```
 
-Do the same with `.env.prod` (second line) if you want to test against production environment (not always necessary). When testing with prod you can just change the `APP_ENV` variable to `prod` from dev and it will load that file instead.
+Writes:
+- `meta/artifacts/db_snapshot.json`
 
-Start the database (clean):
+### Import DB snapshot safely
 
 ```sh
-docker compose down -v --remove-orphans
-docker compose up -d db
-until docker compose exec -T db pg_isready -U utd -d utd_data >/dev/null 2>&1; do
-  echo "waiting for db..."
-  sleep 2
-done
-echo "db ready"
+cd meta
+make import-db
 ```
 
-Install the dependencies needed for preprocessing/vlm:
+`import-db` is transactional inside the import script. If import fails, DB changes are rolled back.
 
-```bash
-uv venv
-source .venv/bin/activate
-uv pip install -r requirements.txt
-```
+## Production/Remote DB Migrate + Import
 
-Then load dataset into the DB:
+To apply migrations and import snapshot against remote/prod DB:
+
+1. Ensure `meta/.env.prod` exists and has valid `DATABASE_URL`.
+2. Ensure backend container is running (`make up`).
+3. Ensure snapshot exists (`make export-db` first, if needed).
+
+Then run:
 
 ```sh
-DATABASE_URL=postgresql+psycopg://utd:utdpass@127.0.0.1:5433/utd_data \
-.venv/bin/python util/preprocess-data.py \
-  --start-at load \
-  --stop-after load \
-  --input ../florence-hurricane-complete/data-example/parsed_data.json
+cd meta
+make prod-migrate-import
 ```
 
-Load additional chat schema:
+This target uses `DATABASE_URL` from `.env.prod` directly and does not overwrite `.env`.
+
+## Environment Notes
+
+- Default dataset location expected by Makefile:
+  - `../florence-hurricane-complete/data-example`
+- Override dataset path for commands with:
 
 ```sh
-docker exec -i "$(docker compose ps -q db)" psql -U utd -d utd_data < ../meta/init-chat-schema.sql
+HOST_DATA_EXAMPLE_DIR=/absolute/path/to/florence-hurricane-complete/data-example make <target>
 ```
 
-Quick verification:
-
-```sh
-docker exec -i "$(docker compose ps -q db)" psql -U utd -d utd_data -c \
-"select to_regclass('public.disasters'), to_regclass('public.image_pairs'), to_regclass('public.locations'), to_regclass('chat.vlm_assessments');"
-
-docker exec -i "$(docker compose ps -q db)" psql -U utd -d utd_data -c \
-"select (select count(*) from disasters) as disasters, (select count(*) from image_pairs) as image_pairs, (select count(*) from locations) as locations;"
-```
-
-If you see `(1 row)` printed twice, everything is good.
-
-Start the backend api:
-
-```sh
-docker compose up -d --build --force-recreate api
-docker compose logs -f api
-```
-
-Remember to shut it down after you are done testing or making changes:
-
-```sh
-docker compose down
-```
-
-### Frontend
-
-cd to the frontend directory.
-
-Install the dependencies:
-
-```sh
-npm i
-```
-
-Run the client:
-
-```sh
-npm run dev
-```
-
-## Batch VLM Predictions
-
-soon
+- Address enrichment behavior:
+  - If `address_map.json` exists in data folder, enrichment uses it first.
+  - Misses fall back to Census geocoder unless map-only mode is used in direct script invocation.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,7 @@ services:
     depends_on:
       postgis:
         condition: service_healthy
-    env_file:
-      - .env
-      - .env.prod
+    env_file: .env
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
- Introduces a unified meta/Makefile workflow for startup and data operations (bootstrap, bootstrap-full, preprocess, vlm-predictions, enrich-addresses, export-db, import-db, reset, etc.).
- Adds prod-migrate-import to run DB migrations + snapshot import against DATABASE_URL from .env.prod without overwriting .env.
- Updates docker-compose.yml/scripts alignment for consistent env and data handling.
- Rewrites START.md to document the new end-to-end run paths (snapshot bootstrap vs full preprocessing).
- Minor housekeeping updates in .gitignore.